### PR TITLE
Fix: Exclude completed appointments from reminder notifications

### DIFF
--- a/appointments.html
+++ b/appointments.html
@@ -1165,6 +1165,7 @@
                     .select('*')
                     .eq('user_id', currentUser.id)
                     .gte('appointment_date', today)
+                    .in('status', ['pending', 'confirmed'])
                     .order('appointment_date', { ascending: true })
                     .limit(1);
 


### PR DESCRIPTION
Patients were receiving notifications for completed appointments. Added status filter to only show 'pending' and 'confirmed' appointments in the reminder bot, excluding 'completed', 'cancelled', and 'declined' appointments.

Changes:
- appointments.html:1168: Added .in('status', ['pending', 'confirmed']) filter